### PR TITLE
use bash expansion

### DIFF
--- a/.functions
+++ b/.functions
@@ -11,7 +11,7 @@ function phpserver() {
 }
 
 function readme() {
-    for readme in README.md README.MD readme.md README.markdown README.txt README.TXT readme.txt README README.mkd; do
+    for readme in {readme,README}.{md,MD,markdown,txt,TXT,mkd}; do
         if [[ -f "$readme" ]]; then
             cat $readme
         fi


### PR DESCRIPTION
alternatively if you wanna be hacky you could do something like

`cat 2>/dev/null {readme,README}.{md,MD,markdown,txt,TXT,mkd}` (hide the no such file or dir messages)