### PR TITLE
i3block config: allow display of free ram >= 10GB

### DIFF
--- a/.i3blocks/config
+++ b/.i3blocks/config
@@ -10,7 +10,7 @@ signal=10
 
 [ram]
 label=
-command=/usr/libexec/i3blocks/memory | grep -E -o '[0-9].[0-9]?G'
+command=/usr/libexec/i3blocks/memory | grep -E -o '[0-9]+.[0-9]?G'
 interval=30
 
 [disk-home]


### PR DESCRIPTION
Original regex dropped leading digits when free memory >= 10GB.